### PR TITLE
Improved generics

### DIFF
--- a/Sources/ConstraintBuilder/ConstraintBuilder.swift
+++ b/Sources/ConstraintBuilder/ConstraintBuilder.swift
@@ -83,7 +83,7 @@ extension LayoutGuide: ConstraintBuildable {
 /// Convenience methods to apply layout constraints to views
 public protocol ViewConstraintBuildable: ConstraintBuildable where Constrained: LayoutContainerView {
 	/// Use superview if available,  `assertionFailure()` if not
-	func withSuperview(_ method: (Constrained) -> Void)
+	func withSuperview(_ method: (LayoutContainerView) -> Void)
 
 	/// Extends all edges to the edges of the superview
 	/// Should result in `assertionFailure` when no superview is available

--- a/Sources/ConstraintBuilder/NSView+ConstraintBuildable.swift
+++ b/Sources/ConstraintBuilder/NSView+ConstraintBuildable.swift
@@ -1,17 +1,18 @@
 #if canImport(AppKit)
 import AppKit
 
-extension NSView: ViewConstraintBuildable {
-	public func withSuperview(_ method: (NSView) -> Void) {
+extension ViewConstraintBuildable where Self: NSView {
+	public func withSuperview(_ method: (LayoutContainerView) -> Void) {
 		guard let superview else {
 			return assertionFailure()
 		}
 		method(superview)
 	}
 
-	public func applyConstraints(@ConstraintBuilder _ builder: (NSView) -> [NSLayoutConstraint]) {
+	public func applyConstraints(@ConstraintBuilder _ builder: (Self) -> [NSLayoutConstraint]) {
 		translatesAutoresizingMaskIntoConstraints = false
 		NSLayoutConstraint.activate(builder(self))
 	}
 }
+extension NSView: ViewConstraintBuildable { }
 #endif

--- a/Sources/ConstraintBuilder/UIView+ConstraintBuildable.swift
+++ b/Sources/ConstraintBuilder/UIView+ConstraintBuildable.swift
@@ -1,17 +1,18 @@
 #if canImport(UIKit)
 import UIKit
 
-extension UIView: ViewConstraintBuildable {
-	public func withSuperview(_ method: (UIView) -> Void) {
+extension ViewConstraintBuildable where Self: UIView {
+	public func withSuperview(_ method: (LayoutContainerView) -> Void) {
 		guard let superview else {
 			return assertionFailure()
 		}
 		method(superview)
 	}
 
-	public func applyConstraints(@ConstraintBuilder _ builder: (UIView) -> [NSLayoutConstraint]) {
+	public func applyConstraints(@ConstraintBuilder _ builder: (Self) -> [NSLayoutConstraint]) {
 		translatesAutoresizingMaskIntoConstraints = false
 		NSLayoutConstraint.activate(builder(self))
 	}
 }
+extension UIView: ViewConstraintBuildable { }
 #endif

--- a/Tests/ConstraintBuilderTests/ConstraintBuilderTests.swift
+++ b/Tests/ConstraintBuilderTests/ConstraintBuilderTests.swift
@@ -2,6 +2,18 @@ import XCTest
 import ConstraintBuilder
 
 final class ConstraintBuilderTests: XCTestCase {
+	class CustomView: UIView {
+		let customGuide = UILayoutGuide()
+		override init(frame: CGRect) {
+			super.init(frame: frame)
+			addLayoutGuide(customGuide)
+			customGuide.extend(to: self)
+		}
+
+		required init?(coder: NSCoder) {
+			fatalError("init(coder:) has not been implemented")
+		}
+	}
 	#if canImport(UIKit) || canImport(tvOS)
 	var superview: UIView!
 	var view: UIView!
@@ -56,5 +68,17 @@ final class ConstraintBuilderTests: XCTestCase {
 
 	func testViewExtendToGuide() {
 		view.extend(to: guide)
+	}
+
+	func testCustomViewConstraints() {
+		let customView = CustomView()
+		superview.addSubview(customView)
+		customView.extendToSuperviewLayoutMargins()
+		customView.applyConstraints {
+			$0.customGuide.leadingAnchor.constraint(equalTo: view.leadingAnchor)
+			$0.customGuide.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+			$0.customGuide.topAnchor.constraint(equalTo: view.topAnchor)
+			$0.customGuide.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+		}
 	}
 }


### PR DESCRIPTION
So `.applyConstraints { }` doesn't cast to UIView. Constraints on guides or subviews to your custom views can now be added 